### PR TITLE
Update lint.rb to cover both -tests.yml and _tests.yml for workflow tests lint check

### DIFF
--- a/bin/lint.rb
+++ b/bin/lint.rb
@@ -1515,10 +1515,10 @@ module Gtn
         else
           # Load tests and run some quick checks:
           possible_tests.each do |test_file|
-            if !test_file.match(/-tests.yml/)
+            if !test_file.match(/[_-]tests?.ya?ml/)
               results += [
                 ReviewDogEmitter.file_error(path: path,
-                                            message: 'Please use the extension -tests.yml ' \
+                                            message: 'Please use the extension -tests.yml or _tests.yml' \
                                                      'for this test file.',
                                             code: 'GTN:032')
               ]


### PR DESCRIPTION
I reported an issue [here](https://github.com/galaxyproject/training-material/issues/5951) about workflow test lint checks on GTN. I believe it is better to accept all combinations of `-tests.yml`, `-tests.yaml`, `_tests.yml`, and `_tests.yaml`. I changed the code to be similar to this code of GTN (here with `match` instead of `grep`):

https://github.com/dadrasarmin/training-material/blob/353367373d11362547eb4e69ec2e5cb7bb119570/bin/list-workflows-with-tests.rb#L11

It seems to me that it should work. But I do not know how can I check it locally.